### PR TITLE
Add basic docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,5 +37,5 @@ jobs:
             mkdocs-material-
       - run: hatch run docs:build
       - name: Deploy to GitHub Pages
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         run: hatch env run -e docs mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,4 +38,4 @@ jobs:
       - run: hatch run docs:build
       - name: Deploy to GitHub Pages
         # if: github.event_name != 'pull_request'
-        run: hatch env run -e docs mkdocs gh-deploy --force
+        run: hatch env run -e docs -- mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: docs
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: hatch run docs:build
+      - name: Deploy to GitHub Pages
+        if: github.event_name != 'pull_request'
+        run: hatch env run -e docs mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,5 +37,5 @@ jobs:
             mkdocs-material-
       - run: hatch run docs:build
       - name: Deploy to GitHub Pages
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: hatch env run -e docs -- mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 coverage.xml
 .idea
 /dist
+/site

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# taskwait
+
+Wait for a task to complete.  This is a very small package and does not really warrant this level of complexity in documentation.  We're using this to help us bootstrap up some ideas around python doc generation.
+
+# Reference
+
+::: taskwait

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+# See here for details:
+# https://squidfunk.github.io/mkdocs-material/setup/
+
+site_name: taskwait
+site_url: https://reside-ic.github.io/taskwait/
+repo_url: https://github.com/reside-ic/taskwait
+repo_name: reside-ic/taskwait
+edit_uri: edit/main/docs/
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+      # edit: material/pencil
+      # view: material/eye
+  features:
+    - content.action.edit
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      primary: blue
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      primary: blue
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      primary: blue
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+plugins:
+- search
+- mkdocstrings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,16 @@ all = [
   "typing",
 ]
 
+[tool.hatch.envs.docs]
+extra-dependencies = [
+  "mkdocs-material",
+  "mkdocstrings-python",
+]
+
+[tool.hatch.envs.docs.scripts]
+build = "mkdocs build"
+serve = "mkdocs serve"
+
 [tool.coverage.run]
 branch = true
 parallel = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,8 +146,8 @@ ignore = [
   "S105", "S106", "S107",
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
-  # Don't require docstrings everywhere for now
-  "D100", "D101", "D102", "D103", "D104", "D105",
+  # These two are incompatible with D211 and D213 respectively.
+  "D203", "D212",
   # Ignore shadowing
   "A001", "A002", "A003",
   # Allow pickle
@@ -166,7 +166,4 @@ unfixable = [
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
-
-[tool.ruff.lint.pydocstyle]
-convention = "numpy"
+"tests/**/*" = ["PLR2004", "S101", "TID252", "D"]

--- a/src/taskwait/__about__.py
+++ b/src/taskwait/__about__.py
@@ -1,4 +1,3 @@
-# SPDX-FileCopyrightText: 2025-present Rich FitzJohn <r.fitzjohn@imperial.ac.uk>
-#
-# SPDX-License-Identifier: MIT
+"""Metadata."""
+
 __version__ = "0.1.2"


### PR DESCRIPTION
The bare minimum.  I've hacked in some quick **reference** docs for the package so that the process has something to chew on.  Notably there are no examples and no equivalents of vignettes because I don't think these actually meaningfully exist in the python world but I am hoping to be proven wrong at some point.

I looked at Sphinx and it's just baffling, still. The docs have to be written in restructured text which I don't like very much, and the setup is complicated and ironically not well documented.

I did wonder about the (somewhat-posit-backed) `quartodoc` but it's also not amazingly documented and it does feel very young still.  I do expect that it's going to feel the most familiar to us ultimately and might be the best bet for real examples.  However, the current best docs for it are apparently watching a screencast so it will remain unknowable to me.

The setup here is fairly simple:

* some work in pyproject.toml to declare the environment and add a few commands
* a mkdocs.yml file which is not too terrible to read - there's a link to the many options it has at the top of the file now
* a skeleton docs/index.md page which contains the written docs plus the magic `::: taskwait` div which the `mkdocstrings` plugin reads to build api docs
* I've also made the `D` ruff (documentation) rules stricter. Getting it to check for unused args required moving to Google-style docstrings rather than numpy ones. I'm ok with that, because I don't know what the supposed benefit of numpy strings is. It does turn out that we get warnings at least from mkdocs if not all args are documented though.

Adding @pratikunterwegs on this mostly for a FYI, but any comments or alternative perspectives very welcome - I know you've been reading about this too

The page is currently built at https://reside-ic.github.io/taskwait/

Or run `hatch run docs:serve` to run it up locally